### PR TITLE
Prompt user for existing mapping replacement

### DIFF
--- a/Sources/KarabouCLI/KarabinerConfigManager.swift
+++ b/Sources/KarabouCLI/KarabinerConfigManager.swift
@@ -35,7 +35,7 @@ class KarabinerConfigManager {
         }
     }
 
-    public func addAppOpen(keyCode: String, modifier: String, app: App) {
+    public func addAppOpen(keyCode: String, modifier: String, app: App, forceOverwrite: Bool = false) {
         if modifier != "right_command" {
             // TODO: throw an error
             print("Warning: Modifier \(modifier) not supported")
@@ -43,9 +43,14 @@ class KarabinerConfigManager {
         }
 
         let hash = encodeKeyAndModifier(keyCode: keyCode, modifier: modifier)
-        guard !mappedKeyAndModifier.contains(hash) else {
+        if mappedKeyAndModifier.contains(hash) && !forceOverwrite {
             // TODO: throw an error, caller should remove first
             return
+        }
+
+        // If we're force overwriting, remove the existing mapping first
+        if mappedKeyAndModifier.contains(hash) && forceOverwrite {
+            remove(keyCode: keyCode, modifier: modifier)
         }
 
         var newRules = karabinerConfig.profiles.first?.complexModifications.rules ?? []
@@ -129,6 +134,11 @@ class KarabinerConfigManager {
 
     public func isModified() -> Bool {
         return _isModified
+    }
+
+    public func getExistingApp(keyCode: String, modifier: String) -> String? {
+        let hash = encodeKeyAndModifier(keyCode: keyCode, modifier: modifier)
+        return mappings[hash]
     }
 
     private func createManipulator(keyCode: String, modifier: String, app: App) -> Manipulator {

--- a/Sources/KarabouCLI/KarabinerConfigManager.swift
+++ b/Sources/KarabouCLI/KarabinerConfigManager.swift
@@ -35,7 +35,7 @@ class KarabinerConfigManager {
         }
     }
 
-    public func addAppOpen(keyCode: String, modifier: String, app: App, forceOverwrite: Bool = false) {
+    public func addAppOpen(keyCode: String, modifier: String, app: App) throws {
         if modifier != "right_command" {
             // TODO: throw an error
             print("Warning: Modifier \(modifier) not supported")
@@ -43,14 +43,9 @@ class KarabinerConfigManager {
         }
 
         let hash = encodeKeyAndModifier(keyCode: keyCode, modifier: modifier)
-        if mappedKeyAndModifier.contains(hash) && !forceOverwrite {
-            // TODO: throw an error, caller should remove first
-            return
-        }
-
-        // If we're force overwriting, remove the existing mapping first
-        if mappedKeyAndModifier.contains(hash) && forceOverwrite {
-            remove(keyCode: keyCode, modifier: modifier)
+        if mappedKeyAndModifier.contains(hash) {
+            let existingApp = mappings[hash] ?? "unknown"
+            throw KarabouError.mappingAlreadyExists(keyCode: keyCode, modifier: modifier, existingApp: existingApp)
         }
 
         var newRules = karabinerConfig.profiles.first?.complexModifications.rules ?? []
@@ -134,11 +129,6 @@ class KarabinerConfigManager {
 
     public func isModified() -> Bool {
         return _isModified
-    }
-
-    public func getExistingApp(keyCode: String, modifier: String) -> String? {
-        let hash = encodeKeyAndModifier(keyCode: keyCode, modifier: modifier)
-        return mappings[hash]
     }
 
     private func createManipulator(keyCode: String, modifier: String, app: App) -> Manipulator {

--- a/Sources/KarabouCLI/KarabouCLI.swift
+++ b/Sources/KarabouCLI/KarabouCLI.swift
@@ -93,30 +93,33 @@ struct KarabouCLI: ParsableCommand {
 
             let manager = KarabinerConfigManager(
                 karabinerConfig: config, destinationRuleName: "KarabouManaged-OpenApps")
+            
+            do {
+                try manager.addAppOpen(keyCode: keyCode!, modifier: modifier, app: app)
                 
-            // Check if mapping already exists
-            if let existingAppBundleId = manager.getExistingApp(keyCode: keyCode!, modifier: modifier) {
+                try FileService.writeJsonFile(url: url, data: manager.getKarabinerConfig())
+                restartKarabiner()
+                
+                print("Rule added successfully")
+            } catch KarabouError.mappingAlreadyExists(let keyCode, let modifier, let existingApp) {
                 let confirmationMessage = 
-                    "A mapping already exists for \(keyCode!) + \(modifier) → \(existingAppBundleId).\nDo you want to remove the existing mapping and add the new one?"
+                    "A mapping already exists for \(keyCode) + \(modifier) → \(existingApp).\nDo you want to remove the existing mapping and add the new one?"
                 let confirmation = Noora().yesOrNoChoicePrompt(
                     question: TerminalText(stringLiteral: confirmationMessage))
                 
-                if !confirmation {
+                if confirmation {
+                    // User confirmed, remove existing and add new
+                    manager.remove(keyCode: keyCode, modifier: modifier)
+                    try manager.addAppOpen(keyCode: keyCode, modifier: modifier, app: app)
+                    
+                    try FileService.writeJsonFile(url: url, data: manager.getKarabinerConfig())
+                    restartKarabiner()
+                    
+                    print("Existing mapping removed and new rule added successfully")
+                } else {
                     print("Operation cancelled. Existing mapping was not changed.")
-                    return
                 }
-                
-                // User confirmed, so we'll overwrite
-                manager.addAppOpen(keyCode: keyCode!, modifier: modifier, app: app, forceOverwrite: true)
-            } else {
-                // No existing mapping, proceed normally
-                manager.addAppOpen(keyCode: keyCode!, modifier: modifier, app: app)
             }
-
-            try FileService.writeJsonFile(url: url, data: manager.getKarabinerConfig())
-            restartKarabiner()
-
-            print("Rule added successfully")
         case .remove:
             if keyCode == nil {
                 throw ValidationError("Key code is required for removing a rule")

--- a/Sources/KarabouCLI/KarabouError.swift
+++ b/Sources/KarabouCLI/KarabouError.swift
@@ -3,4 +3,5 @@ enum KarabouError: Error {
     case bundleURLNotFound
     case configurationReaderFailed
     case configurationWriterFailed
+    case mappingAlreadyExists(keyCode: String, modifier: String, existingApp: String)
 }

--- a/Tests/karabou-cliTests/karabou_serviceTests.swift
+++ b/Tests/karabou-cliTests/karabou_serviceTests.swift
@@ -120,7 +120,7 @@ class KarabouCLITests: XCTestCase {
         let manager = KarabinerConfigManager(
             karabinerConfig: config, destinationRuleName: "KarabouManaged-OpenApps")
 
-        manager.addAppOpen(keyCode: "z", modifier: "right_command", app: APPLE_MUSIC)
+        try manager.addAppOpen(keyCode: "z", modifier: "right_command", app: APPLE_MUSIC)
         
         XCTAssertEqual(manager.hasManipulator(keyCode: "z", modifier: "right_command"), true)
     }
@@ -130,10 +130,30 @@ class KarabouCLITests: XCTestCase {
         let manager = KarabinerConfigManager(
             karabinerConfig: config, destinationRuleName: "KarabouManaged-OpenApps")
 
-        manager.addAppOpen(keyCode: "z", modifier: "right_command", app: APPLE_MUSIC)
+        try manager.addAppOpen(keyCode: "z", modifier: "right_command", app: APPLE_MUSIC)
         manager.remove(keyCode: "z", modifier: "right_command")
 
         XCTAssertEqual(manager.hasManipulator(keyCode: "z", modifier: "right_command"), false)
+    }
+
+    func testConfigManager_addAppOpen_throwsErrorWhenMappingExists() throws {
+        let config = createEmptyConfig()
+        let manager = KarabinerConfigManager(
+            karabinerConfig: config, destinationRuleName: "KarabouManaged-OpenApps")
+
+        // Add initial mapping
+        try manager.addAppOpen(keyCode: "z", modifier: "right_command", app: APPLE_MUSIC)
+        
+        // Try to add another mapping for the same key combination
+        XCTAssertThrowsError(try manager.addAppOpen(keyCode: "z", modifier: "right_command", app: GOOGLE_CHROME)) { error in
+            if case KarabouError.mappingAlreadyExists(let keyCode, let modifier, let existingApp) = error {
+                XCTAssertEqual(keyCode, "z")
+                XCTAssertEqual(modifier, "right_command")
+                XCTAssertEqual(existingApp, "com.apple.Music")
+            } else {
+                XCTFail("Expected mappingAlreadyExists error, got \(error)")
+            }
+        }
     }
 
     func testGoldenDiff1() throws {
@@ -143,7 +163,7 @@ class KarabouCLITests: XCTestCase {
         // TODO: add a file path test case
         let manager = KarabinerConfigManager(
             karabinerConfig: config, destinationRuleName: "KarabouManaged-OpenApps")
-        manager.addAppOpen(keyCode: "z", modifier: "right_command", app: APPLE_MUSIC)
+        try manager.addAppOpen(keyCode: "z", modifier: "right_command", app: APPLE_MUSIC)
         // manager.remove(keyCode: "j", modifier: "right_command")
         let actualConfig = manager.getKarabinerConfig()
 


### PR DESCRIPTION
Add a user prompt to allow overwriting existing key mappings, improving user feedback and control.

This PR refactors the mapping addition logic: `KarabinerConfigManager` now throws an error when a mapping exists, and `KarabouCLI` handles the user prompt and orchestration (remove then add) for a cleaner separation of concerns.